### PR TITLE
Add `fxSearchWithAQL` function to execute AQL searches against Artifactory

### DIFF
--- a/src/fxSearchWithAQL.pq
+++ b/src/fxSearchWithAQL.pq
@@ -1,0 +1,43 @@
+/*
+    fxSearchWithAQL
+
+    Executes a JFrog Artifactory Query Language (AQL) search and returns the results.
+
+    @param      AqlQueryString  (text) The AQL query to execute.
+
+    @return     (table) A table containing the search results. Returns an empty
+                table if the query has no results.
+
+    @example
+                let
+                    MyQuery = "items.find({"repo":"releases"}).include("name", "path")"
+                in
+                    fxSearchWithAQL(MyQuery)
+
+    @requires   A global parameter named 'ArtifactoryHost' must be defined.
+*/
+(AqlQueryString as text) =>
+    let
+        // Configuration
+        BaseHost = ArtifactoryHost,
+        AqlApiEndpoint = BaseHost & "/artifactory/api/search/aql",
+        // Prepare and execute the API POST request
+        BinaryAqlQuery = Text.ToBinary(AqlQueryString),
+        ApiResponse = Web.Contents(
+            AqlApiEndpoint, [
+                Headers = [#"Content-Type" = "text/plain"],
+                Content = BinaryAqlQuery
+            ]
+        ),
+        // Process the JSON response
+        ParsedJson = Json.Document(ApiResponse),
+        ResultsList = Record.FieldOrDefault(ParsedJson, "results", {}),
+        ResultTable = Table.FromList(ResultsList, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
+        ExpandedResults = Table.ExpandRecordColumn(
+            ResultTable,
+            "Column1",
+            {"name", "repo", "path", "type", "size", "created", "modified"},
+            {"Name", "Repo", "Path", "Type", "Size", "Created", "Modified"}
+        )
+    in
+        ExpandedResults

--- a/src/fxSearchWithAQL.pq
+++ b/src/fxSearchWithAQL.pq
@@ -37,12 +37,15 @@
         // Process the JSON response
         ParsedJson = Json.Document(ApiResponse),
         ResultsList = Record.FieldOrDefault(ParsedJson, "results", {}),
-        ResultTable = Table.FromList(ResultsList, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
-        ExpandedResults = Table.ExpandRecordColumn(
-            ResultTable,
-            "Column1",
-            {"name", "repo", "path", "type", "size", "created", "modified"},
-            {"Name", "Repo", "Path", "Type", "Size", "Created", "Modified"}
-        )
+        ResultTable = Table.FromList(ResultsList, Splitter.SplitByNothing(), {"Column1"}, null, ExtraValues.Error),
+        ExpandedResults = if Table.RowCount(ResultTable) > 0 then
+            let
+                SampleRecord = ResultTable{0}[Column1],
+                FieldNames = Record.FieldNames(SampleRecord),
+                ColumnNames = List.Transform(FieldNames, each Text.Proper(_))
+            in
+                Table.ExpandRecordColumn(ResultTable, "Column1", FieldNames, ColumnNames)
+        else
+            #table({}, {})
     in
         ExpandedResults

--- a/src/fxSearchWithAQL.pq
+++ b/src/fxSearchWithAQL.pq
@@ -14,7 +14,7 @@
                 in
                     fxSearchWithAQL(MyQuery)
 
-    @requires   A global parameter named 'ArtifactoryHost' must be defined.
+    @requires   Global parameters 'ArtifactoryHost' and optionally 'ArtifactoryApiKey' must be defined.
 */
 (AqlQueryString as text) =>
     let
@@ -23,9 +23,14 @@
         AqlApiEndpoint = BaseHost & "/artifactory/api/search/aql",
         // Prepare and execute the API POST request
         BinaryAqlQuery = Text.ToBinary(AqlQueryString),
+        BaseHeaders = [#"Content-Type"="text/plain"],
+        AuthHeader = if ArtifactoryApiKey <> null and ArtifactoryApiKey <> ""
+                     then [#"X-JFrog-Art-Api" = ArtifactoryApiKey]
+                     else [], // Add the auth header only if the API key parameter has a value
+        FinalHeaders = Record.Combine({BaseHeaders, AuthHeader}),
         ApiResponse = Web.Contents(
             AqlApiEndpoint, [
-                Headers = [#"Content-Type" = "text/plain"],
+                Headers = FinalHeaders,
                 Content = BinaryAqlQuery
             ]
         ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new search feature enabling users to perform JFrog Artifactory AQL queries and view results in a structured table format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->