### PR TITLE
Add `fxGetDateFromVersion` function to extract embedded dates from version strings, adjust `.editorconfig` indent size to 2 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,4 +10,4 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-indent_size = 4
+indent_size = 2

--- a/src/fxGetDateFromVersion.pq
+++ b/src/fxGetDateFromVersion.pq
@@ -1,0 +1,33 @@
+/*
+    fxGetDateFromVersion
+
+    Parses a single version string to extract its embedded date. This function
+    is a building block for more complex transformations.
+
+    It assumes the date is the 8 characters immediately following the first
+    dot in the version string (format: yyyymmdd).
+
+    @param      version  (text) The version string to parse.
+                         Handles formats like "1.20250603..." and "7.20250520-release-..."
+
+    @return     (date) A date object, or null if the version string could not be parsed.
+
+    @example
+                fxGetDateFromVersion("1.20250603.134420-06cd97c9")
+                // returns #date(2025, 6, 3)
+*/
+let
+    fxGetDateFromVersion = (version as text) =>
+        let
+            parsedDate =
+                try
+                    let
+                        textAfterDot = Text.AfterDelimiter(version, "."),
+                        dateAsText = Text.Start(textAfterDot, 8)
+                    in
+                        Date.FromText(dateAsText, [Format = "yyyyMMdd", Culture = "en-US"])
+                    otherwise null
+        in
+            parsedDate
+in
+    fxGetDateFromVersion


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a function to extract and convert embedded dates from version strings in the format "yyyymmdd".

- **Style**
  - Updated indentation settings to use 2 spaces instead of 4 in configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->